### PR TITLE
removing unnecessary code to dispatch actions

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -69,8 +69,8 @@ export default connect(
         listOfParticipants: state.participants.listOfParticipants,
         selectedParticipant: state.participants.selectedParticipant
     }),
-    dispatch => ({
-        fileUpload: (file) => dispatch(fileUpload(file)),
-        setRandomParticipant: () => dispatch(setRandomParticipant()),
-        removeParticipant: (index) => dispatch(removeParticipant(index))
-    }))(App);
+    {
+        fileUpload: fileUpload,
+        setRandomParticipant: setRandomParticipant,
+        removeParticipant: removeParticipant
+    })(App);


### PR DESCRIPTION
The reason for removing this code is documented here:
https://react-redux.js.org/docs/using-react-redux/connect-dispatching-actions-with-mapdispatchtoprops#defining-mapdispatchtoprops-as-an-object